### PR TITLE
Restructure code and internal packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: go
+
+sudo: false
+
+notifications:
+  email: false
+
+go:
+  - 1.4
+  - tip
+
+script:
+  - go test ./...
+  - go fmt ./...

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/brettchalupa/far/far"
+	"github.com/codegangsta/cli"
+)
+
+func CheckArgs(args cli.Args) bool {
+	var neededArgs bool
+
+	argsCount := len(args)
+
+	if argsCount >= 3 {
+		neededArgs = true
+	} else {
+		if argsCount == 0 {
+			fmt.Println("Please provide the path, original value, and new value")
+		} else if argsCount == 1 {
+			fmt.Println("Please provide the original value and new value")
+		} else if argsCount == 2 {
+			fmt.Println("Please provide the new value")
+		}
+
+		neededArgs = false
+	}
+
+	return neededArgs
+}
+
+func Execute(args cli.Args) {
+	if far.FileExists(args[0]) {
+		count, err := far.FindAndReplace(args[0], args[1], args[2])
+		if err != nil {
+			panic(err)
+		}
+		fmt.Println("Times replaced", count)
+	} else {
+		fmt.Println("Provided file does not exist")
+	}
+}

--- a/far/far.go
+++ b/far/far.go
@@ -1,0 +1,51 @@
+package far
+
+import (
+	"bufio"
+	"os"
+	"strings"
+)
+
+func FileExists(path string) bool {
+	_, err := os.Stat(path)
+
+	if err != nil {
+		return false
+	} else {
+		return true
+	}
+}
+
+func FindAndReplace(path, current, update string) (int, error) {
+	file, _ := os.Open(path)
+	defer file.Close()
+
+	var lines []string
+	scanner := bufio.NewScanner(file)
+
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+
+	write_file, err := os.Create(path)
+	if err != nil {
+		panic(err)
+	}
+	defer write_file.Close()
+
+	writer := bufio.NewWriter(file)
+
+	replaceCount := 0
+
+	for _, line := range lines {
+		if strings.Contains(line, current) {
+			line = strings.Replace(line, current, update, -1)
+			replaceCount++
+		}
+		write_file.WriteString(line + "\n")
+	}
+
+	writer.Flush()
+
+	return replaceCount, nil
+}

--- a/main.go
+++ b/main.go
@@ -1,11 +1,9 @@
 package main
 
 import (
-	"bufio"
-	"fmt"
+	"github.com/brettchalupa/far/cmd"
 	"github.com/codegangsta/cli"
 	"os"
-	"strings"
 )
 
 func main() {
@@ -14,86 +12,10 @@ func main() {
 	app.Usage = "find and replace text in files"
 	app.Authors = []cli.Author{cli.Author{Name: "Brett Chalupa", Email: "brett@brettchalupa.com"}}
 	app.Action = func(c *cli.Context) {
-		if checkArgs(c.Args()) {
-			if fileExists(c.Args()[0]) {
-				count, err := findAndReplace(c.Args()[0], c.Args()[1], c.Args()[2])
-				if err != nil {
-					panic(err)
-				}
-				fmt.Println("Times replaced", count)
-			} else {
-				fmt.Println("Provided file does not exist")
-			}
-		} else {
-			return
+		if cmd.CheckArgs(c.Args()) {
+			cmd.Execute(c.Args())
 		}
 	}
 
 	app.Run(os.Args)
-}
-
-func checkArgs(args cli.Args) bool {
-	var neededArgs bool
-
-	argsCount := len(args)
-
-	if argsCount >= 3 {
-		neededArgs = true
-	} else {
-		if argsCount == 0 {
-			fmt.Println("Please provide the path, original value, and new value")
-		} else if argsCount == 1 {
-			fmt.Println("Please provide the original value and new value")
-		} else if argsCount == 2 {
-			fmt.Println("Please provide the new value")
-		}
-
-		neededArgs = false
-	}
-
-	return neededArgs
-}
-
-func fileExists(path string) bool {
-	_, err := os.Stat(path)
-
-	if err != nil {
-		return false
-	} else {
-		return true
-	}
-}
-
-func findAndReplace(path, current, update string) (int, error) {
-	file, _ := os.Open(path)
-	defer file.Close()
-
-	var lines []string
-	scanner := bufio.NewScanner(file)
-
-	for scanner.Scan() {
-		lines = append(lines, scanner.Text())
-	}
-
-	write_file, err := os.Create(path)
-	if err != nil {
-		panic(err)
-	}
-	defer write_file.Close()
-
-	writer := bufio.NewWriter(file)
-
-	replaceCount := 0
-
-	for _, line := range lines {
-		if strings.Contains(line, current) {
-			line = strings.Replace(line, current, update, -1)
-			replaceCount++
-		}
-		write_file.WriteString(line + "\n")
-	}
-
-	writer.Flush()
-
-	return replaceCount, nil
 }


### PR DESCRIPTION
Extract the code that was in main.go into two different packages: cmd &
far.

cmd is responsible for validating the user input and starting the
finding and replacing.

far is responsible for taking what cmd sends it and finding and
replacing the text.

This structure should be easier to manage (and hopefully easier to
test). It is based, somewhat off of the structure of
https://github.com/exercism/cli

My apologies if this is not very Go-like. :)