### PR TITLE
Update Travis CI config to use Go v1.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ notifications:
   email: false
 
 go:
-  - 1.4
+  - 1.5
   - tip
 
 script:


### PR DESCRIPTION
This updates it to test against the latest Go version, which is what I
am using for development.
