### PR TITLE
Add tests for far package

### DIFF
--- a/far/far_test.go
+++ b/far/far_test.go
@@ -1,0 +1,31 @@
+package far
+
+import "testing"
+
+var fixturePath = "../fixtures/cat.rb"
+
+func TestFileExists(t *testing.T) {
+	fileExists := FileExists(fixturePath)
+
+	if !fileExists {
+		t.Error("Could not find", fixturePath)
+	}
+}
+
+func TestFindAndReplace(t *testing.T) {
+	timesReplaced, err := FindAndReplace(fixturePath, "Cat", "Dog")
+
+	if err != nil {
+		t.Error("Did not expect error, value:", err)
+	}
+
+	if timesReplaced != 6 {
+		t.Errorf("Expected Cat to be replaced 6 times, was replaced %v times", timesReplaced)
+	}
+
+	resetFixture()
+}
+
+func resetFixture() {
+	FindAndReplace(fixturePath, "Dog", "Cat")
+}

--- a/fixtures/cat.rb
+++ b/fixtures/cat.rb
@@ -1,0 +1,7 @@
+class CatCat
+  def meow
+    puts 'meow Cat Cat'
+  end
+end
+
+CatCat.new.meow


### PR DESCRIPTION
This adds a test (and file fixture) to test the functions in the far
package. The fixture file is used to test that it actually finds and
replaces within a file.
